### PR TITLE
node_printer link removed from cloud config file

### DIFF
--- a/js/gw.cloud.config.json
+++ b/js/gw.cloud.config.json
@@ -32,10 +32,6 @@
   "links": [
     {
       "source": "node_sensor",
-      "sink": "node_printer"
-    },
-    {
-      "source": "node_sensor",
       "sink": "iothub_writer"
     }
   ]


### PR DESCRIPTION
The sample wasn't running because printer module wasn't created in modules section of the json file.